### PR TITLE
honor schedule timezone

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 pygerduty==0.12
+pytz==2013b
+tzlocal==1.0


### PR DESCRIPTION
Adds a new config setting for SCHEDULE_TIMEZONE which expects an [Olson timezone name](http://en.wikipedia.org/wiki/Tz_database#Names_of_time_zones) matching the timezone of the configured SCHEDULE_ID. This setting is used to properly compute the values to be used when overriding the schedule via 'pager steal' command.
