### PR TITLE
adding >= for pytz as pip does not work with mentioned version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pygerduty==0.12
-pytz==2013b
+pytz>=2013b
 tzlocal==1.0


### PR DESCRIPTION
Installing err-pagerduty even after installing the requirements fails with "You need those dependencies for /var/lib/err/plugins/err-pagerduty: pytz==2013b" As per http://stackoverflow.com/questions/18230956/could-not-find-a-version-that-satisfies-the-requirement-pytz the version 2013b does not play well. Hence added >= to get latest pytz.